### PR TITLE
Check for error in graphql response and return Deny

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/authoriser/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/authoriser/LambdaSpec.scala
@@ -13,6 +13,7 @@ class LambdaSpec extends LambdaSpecUtils {
       "The process method" should s"$expectedEffect access for file $filename" in {
         stubKmsResponse
         graphqlGetConsignment(filename)
+
         val output = mock[ByteArrayOutputStream]
         val byteArrayCaptor: ArgumentCaptor[Array[Byte]] = ArgumentCaptor.forClass(classOf[Array[Byte]])
         doNothing.when(output).write(byteArrayCaptor.capture())
@@ -25,5 +26,20 @@ class LambdaSpec extends LambdaSpecUtils {
         document.policyDocument.Statement.head.Effect should equal(expectedEffect)
       }
     }
+  }
+
+  "The process method" should "return Deny if the API returns an error" in {
+    stubKmsResponse
+    graphqlReturnError
+    val output = mock[ByteArrayOutputStream]
+    val byteArrayCaptor: ArgumentCaptor[Array[Byte]] = ArgumentCaptor.forClass(classOf[Array[Byte]])
+    doNothing.when(output).write(byteArrayCaptor.capture())
+    doNothing.when(output).close()
+    val input = """{"type": "TOKEN", "methodArn": "a/method/3e133bf3-7a3f-4c56-8e17-f667dc182f02", "authorizationToken": "token"}""".stripMargin
+    val stream = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
+    new Lambda().process(stream, output)
+    val res = byteArrayCaptor.getValue.map(_.toChar).mkString
+    val document: Output = decode[Output](res).right.value
+    document.policyDocument.Statement.head.Effect should equal("Deny")
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/authoriser/LambdaSpecUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/authoriser/LambdaSpecUtils.scala
@@ -2,7 +2,7 @@ package uk.gov.nationalarchives.consignmentexport.authoriser
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
-import com.github.tomakehurst.wiremock.client.WireMock.{okJson, post, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.{forbidden, okJson, post, urlEqualTo}
 import com.github.tomakehurst.wiremock.common.FileSource
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.extension.{Parameters, ResponseDefinitionTransformer}
@@ -46,6 +46,9 @@ class LambdaSpecUtils extends AnyFlatSpec with BeforeAndAfterEach with BeforeAnd
 
   def graphqlGetConsignment(filename: String): StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
     .willReturn(okJson(fromResource(s"json/$filename.json").mkString)))
+
+  def graphqlReturnError: StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
+    .willReturn(forbidden()))
 
   def stubKmsResponse = wiremockKmsServer.stubFor(post(urlEqualTo("/")))
 


### PR DESCRIPTION
If you called the consignment export API with an expired token or an
invalid token, the consignment API was return a 403 which was failing
the lambda and returning a 500 error.

This checks to see if the API has errored and returns Deny if it has.
