### PR TITLE
Update generated graphql dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.15"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "2.2.0"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.141"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.173"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"
   lazy val log4cats = "io.chrisdavenport" %% "log4cats-core"    % "1.1.1"
   lazy val log4catsSlf4j = "io.chrisdavenport" %% "log4cats-slf4j"   % "1.1.1"


### PR DESCRIPTION
The generated graphql was on such an old version, it still expected the
series ID to be mandatory and so was failing for judgment users.

This is the latest version
