### PR TITLE
Use the new modular AWS utils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val root = (project in file("."))
       "TDR Releases" at "s3://tdr-releases-mgmt"
     ),
     libraryDependencies ++= Seq(
-      awsUtils,
+      kmsUtils,
       catsEffect,
       generatedGraphql,
       graphqlClient,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.283"
-  lazy val awsUtils =  "uk.gov.nationalarchives" %% "tdr-aws-utils" % "0.1.53"
+  lazy val kmsUtils =  "uk.gov.nationalarchives" %% "kms-utils" % "0.1.55"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.4.1"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.73"
   lazy val log4cats = "org.typelevel" %% "log4cats-core"    % "2.5.0"

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/authoriser/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/authoriser/Lambda.scala
@@ -14,8 +14,8 @@ import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
 import sttp.client3.{HttpURLConnectionBackend, Identity, SttpBackend}
 import sttp.model.StatusCode
-import uk.gov.nationalarchives.aws.utils.Clients.kms
-import uk.gov.nationalarchives.aws.utils.KMSUtils
+import uk.gov.nationalarchives.aws.utils.kms.KMSClients.kms
+import uk.gov.nationalarchives.aws.utils.kms.KMSUtils
 import uk.gov.nationalarchives.consignmentexport.authoriser.Lambda._
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.error.{HttpException, NotAuthorisedError}


### PR DESCRIPTION
The AWS utils library now publishes different packages for each AWS
service. This updates the imports.
